### PR TITLE
Add buffer name module

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -146,6 +146,11 @@
   "Date face."
   :group 'awesome-tray)
 
+(defface awesome-tray-module-buffer-name-face
+  '((t (:foreground "white" :bold t)))
+  "Buffer name face."
+  :group 'awesome-tray)
+
 (define-minor-mode awesome-tray-mode
   "Modular tray bar."
   :require 'awesome-tray-mode
@@ -240,8 +245,10 @@
         ((string-equal module-name "date")
          (propertize (awesome-tray-module-date-info) 'face 'awesome-tray-module-date-face))
         ((string-equal module-name "last-command")
-         (propertize (awesome-tray-module-last-command-info) 'face 'awesome-tray-module-last-command-face)
-         )))
+         (propertize (awesome-tray-module-last-command-info) 'face 'awesome-tray-module-last-command-face))
+        ((string-equal module-name "buffer-name")
+         (propertize (awesome-tray-module-buffer-name-info) 'face 'awesome-tray-module-buffer-name-face))
+        ))
 
 (defun awesome-tray-module-git-info ()
   (if (executable-find "git")
@@ -262,6 +269,9 @@
 
 (defun awesome-tray-module-last-command-info ()
   (format "%s" last-command))
+
+(defun awesome-tray-module-buffer-name-info ()
+  (format "%s" (buffer-name)))
 
 (defun awesome-tray-show-info ()
   ;; Only flush tray info when current message is empty.

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -147,7 +147,7 @@
   :group 'awesome-tray)
 
 (defface awesome-tray-module-buffer-name-face
-  '((t (:foreground "white" :bold t)))
+  '((t (:foreground "SystemOrangecolor" :bold t)))
   "Buffer name face."
   :group 'awesome-tray)
 


### PR DESCRIPTION
As title, add a module showing buffer name. 

Some screenshots:

dark theme:


![screenshot from 2018-10-12 13-10-55](https://user-images.githubusercontent.com/32809182/46849115-66933980-ce20-11e8-9916-81a84853aab2.png)


light theme:
![screenshot from 2018-10-12 13-10-58](https://user-images.githubusercontent.com/32809182/46849123-71e66500-ce20-11e8-8c24-8f6a75185918.png)

For my personal opinion, showing buffer name may be more useful than mode name, because we can easily judge the major mode from file extension in almost 80% cases, and some people are easily to forget the file name they are editing (for example, me), so I add this module to help others having same problem with me. 

BTW,  some colors cannot be loaded on my system,  I got this error message, 

Unable to load "SystemOrangeColor"
Unable to load "SystemPInkColor"
Unable to load "SystemGrayColor"

, they just display black on light theme and white on dark theme, which is fine for me so I haven't fix it.  I highly recommend you to test other colors for displaying buffer name if you decide to merge the PR.
