### PR TITLE
add (require 'cl) for remove-if

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -106,7 +106,7 @@
 ;;
 
 ;;; Require
-
+(require 'cl)
 
 ;;; Code:
 (defgroup awesome-tray nil


### PR DESCRIPTION
As title, I think it's safer to add this, otherwise it may cause error. (Actually I get error that emacs can't find remove-if today :D