### PR TITLE
Add file-path module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,57 @@ With Emacs, we only need to focus on very little information, such as time, curr
 Excessive information can seriously interfere with our attention.
 
 ## Installation
+Clong this repository
+
+```console
+$ git clone --depth=1 https://github.com/manateelazycat/awesome-tray.git
+```
+
 Then put awesome-tray.el to your load-path.
 
-The load-path is usually ~/elisp/.
-
-It's set in your ~/.emacs like this:
+The load-path is usually `~/elisp/`. It's set in your `~/.emacs` like this:
 
 ```Elisp
+(add-to-list `load-path (expand-file-name "~/elisp"))
 (require 'awesome-tray)
 (awesome-tray-mode 1)
 ```
 
 ## Customize
-You can controll modules through option ```awesome-tray-active-modules```
-You can find all modules name through variable ```awesome-tray-all-modules```
+You can controll modules through option ```awesome-tray-active-modules```.
+
+You can find all modules name in the keys of variable ```awesome-tray-module-alist```.
+
+## Create a Module
+Let's create a module that says hello to you. With a module you need:
+
+- A name. Let's simply call it "hello".
+
+- A info function that returns the string to be displayed. Here's a simple one
+
+  ``` emacs-lisp
+  (defun my-module-hello-info ()
+    (concat "Hello " (user-login-name) "!"))
+  ```
+
+  A complex info function may encounter an error, awesome-tray will handle this and not show any information there.
+
+- a face. Let's use a simple yet elegant italic style:
+
+  ``` emacs-lisp
+  (defface my-module-hello-face
+    '((t (:italic t)))
+    "Hello module face."
+    :group 'awesome-tray)
+  ```
+
+- Awesome-tray uses `awesome-tray-module-alist` to find informations about a module. Let's put ours in it:
+
+  ``` emacs-lisp
+  (add-to-list 'awesome-tray-module-alist
+             '("hello" . (my-module-hello-info my-module-hello-face)))
+  ```
+
+- Now put `"hello"` in the `awesome-tray-active-modules` list, and you will see awesome-tray say hello to you!
+
+If you created a module that could be useful to others, please consider contributing it to awesome-tray!

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -1,4 +1,4 @@
-;;; awesome-tray.el ---  Modular tray bar
+;; awesome-tray.el ---  Modular tray bar
 
 ;; Filename: awesome-tray.el
 ;; Description: Modular tray bar
@@ -261,6 +261,14 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
   "Parent dir face."
   :group 'awesome-tray)
 
+(defface awesome-tray-module-file-path-face
+  '((((background light))
+     :foreground "#5e8e2e" :bold t)
+    (t
+     :foreground "#9ded4d" :bold t))
+  "Parent dir face."
+  :group 'awesome-tray)
+
 (defface awesome-tray-module-awesome-tab-face
   '((((background light))
      :foreground "#b83059" :bold t)
@@ -305,6 +313,7 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
     ("circe" . (awesome-tray-module-circe-info awesome-tray-module-circe-face))
     ("date" . (awesome-tray-module-date-info awesome-tray-module-date-face))
     ("evil" . (awesome-tray-module-evil-info awesome-tray-module-evil-face))
+    ("file-path" . (awesome-tray-module-file-path-info awesome-tray-module-file-path-face))
     ("git" . (awesome-tray-module-git-info awesome-tray-module-git-face))
     ("last-command" . (awesome-tray-module-last-command-info awesome-tray-module-last-command-face))
     ("location" . (awesome-tray-module-location-info awesome-tray-module-location-face))
@@ -434,6 +443,36 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
   (if (derived-mode-p 'dired-mode)
       ""
     (format "dir:%s" (file-name-nondirectory (directory-file-name default-directory)))))
+
+(defun awesome-tray-module-file-path-info ()
+  (if (not buffer-file-name)
+      (format "%s" (buffer-name))
+    (let* ((file-path (split-string (buffer-file-name) "/" t))
+           (lastind (1- (length file-path)))
+           (modp (if (buffer-modified-p) "*" "")))
+      (cond
+       ((>= (length file-path) 5)
+        (concat modp
+                ".../"
+                (string-join
+                 (mapcar (lambda (s) (substring s 0 1))
+                         (cl-subseq file-path -4 -2)) "/")
+                "/"
+                (string-join
+                 (cl-subseq file-path -2) "/")))
+       ((>= (length file-path) 3)
+        (concat modp
+                "/"
+                (string-join
+                 (mapcar (lambda (s) (substring s 0 1))
+                         (cl-subseq file-path 0 -2)) "/")
+                "/"
+                (string-join
+                 (cl-subseq file-path -2) "/")))
+       (t
+        (concat modp
+                "/"
+                (string-join file-path "/")))))))
 
 (defun awesome-tray-module-awesome-tab-info ()
   (with-demoted-errors

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -15,7 +15,7 @@
 ;;
 ;; Features that might be required by this library:
 ;;
-;; `cl'
+;; `cl-lib'
 ;;
 
 ;;; This file is NOT part of GNU Emacs
@@ -158,7 +158,7 @@
 ;;
 
 ;;; Require
-(require 'cl)
+(require 'cl-lib)
 
 ;;; Code:
 (defgroup awesome-tray nil
@@ -293,14 +293,25 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
 
 (defvar awesome-tray-active-p nil)
 
-(defvar awesome-tray-all-modules
-  '("last-command" "parent-dir" "git" "buffer-name" "mode-name" "location" "rvm" "date" "circe" "awesome-tab" "evil"))
-
 (defvar awesome-tray-git-command-last-time 0)
 
 (defvar awesome-tray-git-command-cache "")
 
 (defvar awesome-tray-last-tray-info nil)
+
+(defvar awesome-tray-module-alist
+  '(("awesome-tab" . (awesome-tray-module-awesome-tab-info awesome-tray-module-awesome-tab-face))
+    ("buffer-name" . (awesome-tray-module-buffer-name-info awesome-tray-module-buffer-name-face))
+    ("circe" . (awesome-tray-module-circe-info awesome-tray-module-circe-face))
+    ("date" . (awesome-tray-module-date-info awesome-tray-module-date-face))
+    ("evil" . (awesome-tray-module-evil-info awesome-tray-module-evil-face))
+    ("git" . (awesome-tray-module-git-info awesome-tray-module-git-face))
+    ("last-command" . (awesome-tray-module-last-command-info awesome-tray-module-last-command-face))
+    ("location" . (awesome-tray-module-location-info awesome-tray-module-location-face))
+    ("parent-dir" . (awesome-tray-module-parent-dir-info awesome-tray-module-parent-dir-face))
+    ("mode-name" . (awesome-tray-module-mode-name-info awesome-tray-module-mode-name-face))
+    ("rvm" . (awesome-tray-module-rvm-info awesome-tray-module-rvm-face))
+    ))
 
 (defun awesome-tray-enable ()
   ;; Save mode-line colors when first time.
@@ -368,29 +379,12 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
     (format "Awesome Tray broken.")))
 
 (defun awesome-tray-get-module-info (module-name)
-  (cond ((string-equal module-name "git")
-         (propertize (awesome-tray-module-git-info) 'face 'awesome-tray-module-git-face))
-        ((string-equal module-name "rvm")
-         (propertize (awesome-tray-module-rvm-info) 'face 'awesome-tray-module-rvm-face))
-        ((string-equal module-name "mode-name")
-         (propertize (awesome-tray-module-mode-name-info) 'face 'awesome-tray-module-mode-name-face))
-        ((string-equal module-name "location")
-         (propertize (awesome-tray-module-location-info) 'face 'awesome-tray-module-location-face))
-        ((string-equal module-name "date")
-         (propertize (awesome-tray-module-date-info) 'face 'awesome-tray-module-date-face))
-        ((string-equal module-name "last-command")
-         (propertize (awesome-tray-module-last-command-info) 'face 'awesome-tray-module-last-command-face))
-        ((string-equal module-name "buffer-name")
-         (propertize (awesome-tray-module-buffer-name-info) 'face 'awesome-tray-module-buffer-name-face))
-        ((string-equal module-name "parent-dir")
-         (propertize (awesome-tray-module-parent-dir-info) 'face 'awesome-tray-module-parent-dir-face))
-        ((string-equal module-name "circe")
-         (propertize (awesome-tray-module-circe-info) 'face 'awesome-tray-module-circe-face))
-        ((string-equal module-name "awesome-tab")
-         (propertize (awesome-tray-module-awesome-tab-info) 'face 'awesome-tray-module-awesome-tab-face))
-        ((string-equal module-name "evil")
-         (propertize (awesome-tray-module-evil-info) 'face 'awesome-tray-module-evil-face))
-        ))
+  (let* ((func (ignore-errors (cadr (assoc module-name awesome-tray-module-alist))))
+         (face (ignore-errors (cddr (assoc module-name awesome-tray-module-alist))))
+         (info (ignore-errors (propertize (funcall func) 'face face))))
+    (if info
+        info
+      (propertize "" 'face face))))
 
 (defun awesome-tray-module-git-info ()
   (if (executable-find "git")


### PR DESCRIPTION
当 buffer 不是文件时，显示 buffer 名称，否则显示路径。路径过长时，一级以上的父目录会用首字母或 `...` 表示。

这个模块实现了 https://github.com/manateelazycat/awesome-tray/issues/26 中的想法。我认为我们应当尽量截短 awesome-tab 模块的信息。若用户关注文件所在的目录，可以选择使用 file-path 或 parent-dir。

这个补丁假设了 https://github.com/manateelazycat/awesome-tray/pull/27 已经被接收。请先 merge 那个，再 merge 这个。