### PR TITLE
doc: Add information about each module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,17 @@ The load-path is usually `~/elisp/`. It's set in your `~/.emacs` like this:
 ## Customize
 You can controll modules through option ```awesome-tray-active-modules```.
 
-You can find all modules name in the keys of variable ```awesome-tray-module-alist```.
+You can find all modules name in the keys of variable ```awesome-tray-module-alist```. Currently we have:
+
+- `awesome-tab`: Show group information of [awesome-tab](https://github.com/manateelazycat/awesome-tab).
+- `circe`: Show circe tracking buffer information.
+- `evil`: Show evil state.
+- `file-path`: Show file path. Parent directories above 1 level are shown using first letter or `...`.
+- `git`: Show current branch.
+- `location`: Show point position in buffer.
+- `parent-dir`: Show direct parent directory.
+- `rvm`: Show Ruby version information given by `rvm-prompt`.
+- `buffer-name`, `date`, ...: The name says itself.
 
 ## Create a Module
 Let's create a module that says hello to you. With a module you need:

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -446,6 +446,14 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
             (if (buffer-modified-p) "*" "")
             (file-name-nondirectory (directory-file-name default-directory)))))
 
+(defun awesome-tray-shrink-dir-name (name)
+  "Shrink NAME to be its first letter, or the first two if starts \".\"
+
+NAME is a string, typically a directory name."
+  (if (string= "." (substring name 0 1))
+      (substring name 0 2)
+    (substring name 0 1)))
+
 (defun awesome-tray-module-file-path-info ()
   (if (not buffer-file-name)
       (format "%s" (buffer-name))
@@ -457,7 +465,7 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
         (concat modp
                 ".../"
                 (string-join
-                 (mapcar (lambda (s) (substring s 0 1))
+                 (mapcar #'awesome-tray-shrink-dir-name
                          (cl-subseq file-path -4 -2)) "/")
                 "/"
                 (string-join
@@ -466,7 +474,7 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
         (concat modp
                 "/"
                 (string-join
-                 (mapcar (lambda (s) (substring s 0 1))
+                 (mapcar #'awesome-tray-shrink-dir-name
                          (cl-subseq file-path 0 -2)) "/")
                 "/"
                 (string-join


### PR DESCRIPTION
如题。此外刚刚不小心把另一个改动推到同一个分支了，那个是让以 `.` 开头的目录在 file-path 中保留两个字符，比如 `.emacs.d` 会缩短成 `.e`。