### PR TITLE
improve file-path module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can find all modules name in the keys of variable ```awesome-tray-module-ali
 - `circe`: Show circe tracking buffer information.
 - `date`: Show current date.
 - `evil`: Show evil state.
-- `file-path`: Show file path. Parent directories above 1 level are shown using first letter or `...`.
+- `file-path`: Show file path with full customizability. When the path is long, it can be shrinked into something like `.../.em/el/awesome-tray/awesome-tray.el`. See `awesome-tray-file-path-***` variables for details.
 - `git`: Show current branch.
 - `last-command`: Show last execute command.
 - `location`: Show point position in buffer.

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -189,6 +189,32 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
   :type 'integer
   :group 'awesome-tray)
 
+(defcustom awesome-tray-file-path-show-filename nil
+  "Show filename in file-path module or not."
+  :type 'boolean
+  :group 'awesome-tray)
+
+(defcustom awesome-tray-file-path-truncated-name-length 1
+  "In file-path module, how many letters to leave when truncate dirname.
+
+Beginning dots are not counted."
+  :type 'integer
+  :group 'awesome-tray)
+
+(defcustom awesome-tray-file-path-full-dirname-levels 2
+  "In file-path module, how many levels of parent directories should be shown in
+their full name."
+  :type 'integer
+  :group 'awesome-tray)
+
+(defcustom awesome-tray-file-path-truncate-dirname-levels 0
+  "In file-path module, how many levels of parent directories should be shown in
+their first character.
+
+These goes before those shown in their full names."
+  :type 'integer
+  :group 'awesome-tray)
+
 (defface awesome-tray-module-git-face
   '((((background light))
      :foreground "#cc2444" :bold t)
@@ -450,39 +476,42 @@ Maybe you need set this option with bigger value to speedup on Windows platform.
   "Shrink NAME to be its first letter, or the first two if starts \".\"
 
 NAME is a string, typically a directory name."
-  (if (string= "." (substring name 0 1))
-      (substring name 0 2)
-    (substring name 0 1)))
+  (let ((dot-num (if (string-match "\\.+" name)
+                     (length (match-string 0 name))
+                   0)))
+    (substring name 0 (+ dot-num awesome-tray-file-path-truncated-name-length))))
 
 (defun awesome-tray-module-file-path-info ()
   (if (not buffer-file-name)
       (format "%s" (buffer-name))
     (let* ((file-path (split-string (buffer-file-name) "/" t))
-           (lastind (1- (length file-path)))
-           (modp (if (buffer-modified-p) "*" "")))
-      (cond
-       ((>= (length file-path) 5)
-        (concat modp
-                ".../"
-                (string-join
-                 (mapcar #'awesome-tray-shrink-dir-name
-                         (cl-subseq file-path -4 -2)) "/")
-                "/"
-                (string-join
-                 (cl-subseq file-path -2) "/")))
-       ((>= (length file-path) 3)
-        (concat modp
-                "/"
-                (string-join
-                 (mapcar #'awesome-tray-shrink-dir-name
-                         (cl-subseq file-path 0 -2)) "/")
-                "/"
-                (string-join
-                 (cl-subseq file-path -2) "/")))
-       (t
-        (concat modp
-                "/"
-                (string-join file-path "/")))))))
+           (shown-path)
+           (path-len (length file-path))
+           (modp (if (buffer-modified-p) "*" ""))
+           (full-num awesome-tray-file-path-full-dirname-levels)
+           (trunc-num awesome-tray-file-path-truncate-dirname-levels)
+           (show-name awesome-tray-file-path-show-filename))
+      (when (> path-len (+ 1 full-num))
+        (push (string-join
+               (mapcar #'awesome-tray-shrink-dir-name
+                       (cl-subseq file-path
+                                  (max 0 (- path-len (+ 1 full-num trunc-num)))
+                                  (- path-len (1+ full-num)))) "/")
+              shown-path))
+      (when (> path-len 1)
+        (push (string-join
+               (cl-subseq file-path
+                          (max 0 (- path-len (1+ full-num)))
+                          (1- path-len)) "/")
+              shown-path))
+      (when show-name
+        (push (car (last file-path)) shown-path))
+      (concat modp
+              (if (<= path-len (+ 1 full-num trunc-num))
+                  "/"
+                ".../")
+              (string-join (nreverse (cl-remove "" shown-path)) "/")
+              (when (not show-name) "/")))))
 
 (defun awesome-tray-module-awesome-tab-info ()
   (with-demoted-errors


### PR DESCRIPTION
现在可以定制显示几级完整路径，显示几级截短的路径，截短到多短，以及是否显示文件名。事实上已经覆盖 parent-dir 了，除了显示风格不同：parent-dir 总是显示 `dir: dirname`，file-path 经过定制可以显示 `.../dirname/`。