### PR TITLE
fix: calculate string length using string-width

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -557,13 +557,13 @@ Otherwise calculate current frame's width."
   (let* ((tray-info (awesome-tray-build-info)))
     (with-current-buffer " *Minibuf-0*"
       (erase-buffer)
-      (insert (concat (make-string (max 0 (- (awesome-tray-get-frame-width) (length tray-info) awesome-tray-info-padding-right)) ?\ ) tray-info)))))
+      (insert (concat (make-string (max 0 (- (awesome-tray-get-frame-width) (string-width tray-info) awesome-tray-info-padding-right)) ?\ ) tray-info)))))
 
 (defun awesome-tray-get-echo-format-string (message-string)
   (let* ((tray-info (awesome-tray-build-info))
-         (blank-length (- (awesome-tray-get-frame-width) (length tray-info) (length message-string) awesome-tray-info-padding-right))
-         (empty-fill-string (make-string (max 0 (- (awesome-tray-get-frame-width) (length tray-info) awesome-tray-info-padding-right)) ?\ ))
-         (message-fill-string (make-string (max 0 (- (awesome-tray-get-frame-width) (length message-string) (length tray-info) awesome-tray-info-padding-right)) ?\ )))
+         (blank-length (- (awesome-tray-get-frame-width) (string-width tray-info) (string-width message-string) awesome-tray-info-padding-right))
+         (empty-fill-string (make-string (max 0 (- (awesome-tray-get-frame-width) (string-width tray-info) awesome-tray-info-padding-right)) ?\ ))
+         (message-fill-string (make-string (max 0 (- (awesome-tray-get-frame-width) (string-width message-string) (string-width tray-info) awesome-tray-info-padding-right)) ?\ )))
     (prog1
         (if (> blank-length 0)
             ;; Fill message's end with whitespace to keep tray info at right of minibuffer.


### PR DESCRIPTION
这个其实在 https://github.com/manateelazycat/awesome-tray/issues/18 中也提到了。但 `string-width` 总以为一个中文字符是 2 个单位宽的，所以只有在终端下、或使用严格半宽的西文字体时才正常。大多数情况下看上去是这样的，右边多一段空白：

![image](https://user-images.githubusercontent.com/28714352/63220716-fc75be80-c1bf-11e9-9f92-1ca87a0e77f2.png)

但还是比原来有中文就会折行要好些。

因为 Emacs 并不能搞右对齐之类的东西，如果要完美的话我想唯一的方法是让用户指定一个 CJK 字符有多宽，在计算宽度时数一数有几个 CJK 字符再算，但是就太麻烦了。