### PR TITLE
fix: match point symbols anywhere, and in special cases, the file-path is displayed as "//"

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -482,7 +482,7 @@ These goes before those shown in their full names."
   "Shrink NAME to be its first letter, or the first two if starts \".\"
 
 NAME is a string, typically a directory name."
-  (let ((dot-num (if (string-match "\\.+" name)
+  (let ((dot-num (if (string-match "^\\.+" name)
                      (length (match-string 0 name))
                    0)))
     (substring name 0 (+ dot-num awesome-tray-file-path-truncated-name-length))))
@@ -517,7 +517,7 @@ NAME is a string, typically a directory name."
                   "/"
                 ".../")
               (string-join (nreverse (cl-remove "" shown-path)) "/")
-              (when (not show-name) "/")))))
+              (when (and shown-path (not show-name)) "/")))))
 
 (defun awesome-tray-module-awesome-tab-info ()
   (with-demoted-errors


### PR DESCRIPTION
1. 在目录名中有“`.`”时，截断时保留的字符数会无条件加1，按照文档字符串来看，应该只匹配到最开始位置有"`.`"的情况则保留的字符数加1.
例如，截断时，`emacs.d` 保留两个字符，期望显示为 `em`，实际截断后会显示为 `ema`，事实上保留了3个字符长度。

2. 极端情况下( 比如，打开 `/test.el` )，在配置中设置显示 `file-path`，`show-name` 为 `nil`，这时打开 `/test.el` ，`file-path` 会显示为 `//`