### PR TITLE
fix:error if the number of reserved characters is greater than the length of directory name

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -485,7 +485,7 @@ NAME is a string, typically a directory name."
   (let ((dot-num (if (string-match "^\\.+" name)
                      (length (match-string 0 name))
                    0)))
-    (substring name 0 (+ dot-num awesome-tray-file-path-truncated-name-length))))
+    (substring name 0 (min (length name) (+ dot-num awesome-tray-file-path-truncated-name-length)))))
 
 (defun awesome-tray-module-file-path-info ()
   (if (not buffer-file-name)


### PR DESCRIPTION
截断时，当保留的字符数目大于目录名长度时无法显示 `file-path`。
具体原因参考 `substring` 函数的文档说明：
— Function: **substring** _string &optional start end_

An `args-out-of-range` error is signaled if _start_ indicates a character following _end_, or if either integer is out of range for _string_.