### PR TITLE
Header correction

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -1,4 +1,4 @@
-;; awesome-tray.el ---  Modular tray bar
+;;; awesome-tray.el ---  Modular tray bar
 
 ;; Filename: awesome-tray.el
 ;; Description: Modular tray bar


### PR DESCRIPTION
Headers should have 3 `;`, according to the [guidelines](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)
Related to [this issue](https://github.com/quelpa/quelpa-use-package/issues/14)