### PR TITLE
Allow empty face specs in modules and show literal constants

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -257,6 +257,10 @@ These goes before those shown in their full names."
   :type 'integer
   :group 'awesome-tray)
 
+(defface awesome-tray-default-face '((t :inherit default))
+  "Face for string constant ouside modules."
+  :group 'awesome-tray)
+
 (defface awesome-tray-module-git-face
   '((((background light))
      :foreground "#cc2444" :bold t)
@@ -473,10 +477,13 @@ These goes before those shown in their full names."
 (defun awesome-tray-get-module-info (module-name)
   (let* ((func (ignore-errors (cadr (assoc module-name awesome-tray-module-alist))))
          (face (ignore-errors (cddr (assoc module-name awesome-tray-module-alist))))
-         (info (ignore-errors (propertize (funcall func) 'face face))))
-    (if info
-        info
-      (propertize "" 'face face))))
+         (raw-info (ignore-errors (funcall func)))
+         (info (ignore-errors (if face (propertize raw-info 'face face) raw-info))))
+    (if func
+        (if info
+            info
+          (propertize "" 'face face))
+      (propertize module-name 'face 'awesome-tray-default-face))))
 
 (defun awesome-tray-module-git-info ()
   (if (executable-find "git")


### PR DESCRIPTION
- Let the specification of a module omit its face, in which case none
is applied: that way, the info function can change the face on the
fly.

- When a string in awesome-tray-active-modules is not the name of a
registered module, show it verbatim (using a custom face): that way,
one can introduce extra separators or spaces, and also immediately see
if there's an unknown module there.