### PR TITLE
[new feature] allow modeline face depends on buffer status

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -530,7 +530,10 @@ These goes before those shown in their full names."
 
 (defun awesome-tray-get-module-info (module-name)
   (let* ((func (ignore-errors (cadr (assoc module-name awesome-tray-module-alist))))
-         (face (ignore-errors (cddr (assoc module-name awesome-tray-module-alist))))
+         (face-param (ignore-errors (caddr (assoc module-name awesome-tray-module-alist))))
+				 (face (cond ((functionp face-param) (funcall face-param))
+										 ((facep face-param) face-param)
+										 (t nil)))
          (raw-info (ignore-errors (funcall func)))
          (info (ignore-errors (if face (propertize raw-info 'face face) raw-info))))
     (if func


### PR DESCRIPTION
I augmented `awesome-tray-module-alist` takes a function as the face of a module. This allows a module to have difference faces for different cases (e.g., `git-info` can be red when there is uncommitted files).