### PR TITLE
anzu: Fixed anzu enabling the modeline and removed useless code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The load-path is usually `~/elisp/`. It's set in your `~/.emacs` like this:
 ## Customize Module
 You can control modules through option ```awesome-tray-active-modules```.
 
-**When removing the git module load the awesome-tray-mode after setting the modules to prevent useless hooks**
+**When changing the modules load awesome-tray-mode after setting the modules to prevent useless hooks and changes**
 
 You can find all modules name in the keys of variable ```awesome-tray-module-alist```. Currently we have:
 


### PR DESCRIPTION
the anzu code is from doom-modeline
anzu is enabling the modeline and the after-load block is actually useless