### PR TITLE
get correct frame width when using daemon, fix #58

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -1024,7 +1024,10 @@ If right is non nil, replace to the right"
 (defun awesome-tray-get-frame-width ()
   "Only calculating a main Frame width, to avoid wrong width when new frame, such as `snails'."
   (if (display-graphic-p)
-      (with-selected-frame (car (last (frame-list)))
+      (with-selected-frame
+          (if (daemonp)
+              (car (last (butlast (frame-list))))
+            (car (last (frame-list))))
         (frame-width))
     (frame-width)))
 


### PR DESCRIPTION
当 emacs 以守护模式运行时，有一个看不到的 Frame 被创建，用 emacsclient 创建 Frame 后，(frame-list) 实际上会返回两个 frame，倒数第一个是看不到的 frame ，倒数第二个才是能看见的 main frame 

```
(#<frame Emacs 000002017a3a7f40> #<frame F1 00000201622388d0>)
```