### PR TITLE
don't show battery remaining time on mac

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -727,7 +727,9 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
                  (setq battery-status (battery-format " [%p%%]" battery-info)))
                 ((member battery-type '("off-line" "BAT" "Battery"))
                  (setq battery-type "OFF")
-                 (setq battery-status (battery-format " [%p%% %t]" battery-info))))
+                 (if (eq system-type 'darwin)
+                     (setq battery-status (battery-format " [%p%%]" battery-info))
+                     (setq battery-status (battery-format " [%p%% %t]" battery-info)))))
 
           ;; Update battery cache.
           (setq awesome-tray-battery-status-cache (concat battery-type battery-status)))


### PR DESCRIPTION
Since MacOS Sierra 10.12.2, mac does not supply battery remaining time[1].
The `%t` in `battery-format` will be replaced with `N/A`.
Therefore, it might be reasonable to not show battery remaining time on MacOS.

[1] Emacs get battery status in `battery-status-function`, which uses `pmset` to get battery status:
```
((and (eq system-type 'darwin)
            (ignore-errors
              (with-temp-buffer
                (and (eq (call-process "pmset" nil t nil "-g" "ps") 0)
                     (not (bobp))))))
#'battery-pmset)
```
On MacOS Ventura 13.2.1, this command will show:
```
> pmset -g ps
Now drawing from 'AC Power'
 -InternalBattery-0 (id=7405667)	100%; charged; 0:00 remaining present: true
> pmset -g ps
Now drawing from 'Battery Power'
 -InternalBattery-0 (id=7405667)	100%; discharging; (no estimate) present: true
```
No remaining time indeed.