### PR TITLE
Combine location and pdf-view-page to save minibuffer space.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ You can find all modules name in the keys of variable ```awesome-tray-module-ali
 - `git`: Show git information.
 - `last-command`: Show last execute command.
 - `location`: Show point position in buffer.
+- `pdf-view-page`: Show page number in pdf-view-mode.
+- `location-or-page`: Show location or pdf page number depends on current mode.
 - `parent-dir`: Show direct parent directory.
 - `mode-name`: Show major mode name.
 - `rvm`: Show Ruby version information given by `rvm-prompt`.
@@ -80,7 +82,6 @@ You can find all modules name in the keys of variable ```awesome-tray-module-ali
 - `buffer-read-only`: Show read only status.
 - `belong`: Show which class/function status, need install `treesit` first.
 - `org-pomodoro`: Show `org-pomodoro` status. Denote the rest time of pomodoro by `[.]`, short break by `(.)` and long break by `{.}`.
-- `pdf-view-page`: Show page number in pdf-view-mode.
 - `flymake`: Show Flymake state.
 - `meow`: Show meow state.
 - `mpd`: Show mpd information using [libmpdel](https://github.com/mpdel/libmpdel), you need to connect to a mpd profile, use `(libmpdel-connect-profile (libmpdel--select-profile))` unless you have multiple profiles.

--- a/awesome-tray-faces.el
+++ b/awesome-tray-faces.el
@@ -135,6 +135,12 @@
   "Location face."
   :group 'awesome-tray)
 
+(defface awesome-tray-module-location-or-page-face
+  '((((background light)) :inherit awesome-tray-orange-face)
+    (t :inherit awesome-tray-orange-face))
+  "Location or page face."
+  :group 'awesome-tray)
+
 (defface awesome-tray-module-word-count-face
   '((((background light)) :inherit awesome-tray-orange-face)
     (t :inherit awesome-tray-orange-face))

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -770,12 +770,10 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
 
 (defun awesome-tray-module-location-or-page-info ()
   "Show Location or PDF page depends on current mode."
-  (with-demoted-errors
-      ""
-    (if (and (featurep 'pdf-view)
-             (derived-mode-p 'pdf-view-mode))
-        (awesome-tray-module-pdf-view-page-info)
-      (awesome-tray-module-location-info))))
+  (let ((page-info (awesome-tray-module-pdf-view-page-info)))
+    (if (string= page-info "")
+        (awesome-tray-module-location-info)
+      page-info)))
 
 (with-eval-after-load 'libmpdel
   (add-hook 'libmpdel-current-playlist-changed-hook 'awesome-tray-mpd-command-update-cache)

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -80,6 +80,9 @@
 ;;
 
 ;;; Change log:
+;; 2023/06/12
+;;      * Add `awesome-tray-module-location-or-page-info' to show location or pdf page.
+;;
 ;; 2023/06/03
 ;;      * Add `awesome-tray-module-celestial-info' to show moon phase date and sunrise/sunset time.
 ;;      * Add `awesome-tray-location-info-all', `awesome-tray-location-info-top',
@@ -517,6 +520,7 @@ Example:
     ("git" . (awesome-tray-module-git-info awesome-tray-module-git-face))
     ("last-command" . (awesome-tray-module-last-command-info awesome-tray-module-last-command-face))
     ("location" . (awesome-tray-module-location-info awesome-tray-module-location-face))
+    ("location-or-page" . (awesome-tray-module-location-or-page-info awesome-tray-module-location-or-page-face))
     ("parent-dir" . (awesome-tray-module-parent-dir-info awesome-tray-module-parent-dir-face))
     ("mode-name" . (awesome-tray-module-mode-name-info awesome-tray-module-mode-name-face))
     ("rvm" . (awesome-tray-module-rvm-info awesome-tray-module-rvm-face))
@@ -763,6 +767,15 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
       (string-replace
        " Bottom" awesome-tray-location-info-bottom
        (format-mode-line awesome-tray-location-format))))))
+
+(defun awesome-tray-module-location-or-page-info ()
+  "Show Location or PDF page depends on current mode."
+  (with-demoted-errors
+      ""
+    (if (and (featurep 'pdf-view)
+             (derived-mode-p 'pdf-view-mode))
+        (awesome-tray-module-pdf-view-page-info)
+      (awesome-tray-module-location-info))))
 
 (with-eval-after-load 'libmpdel
   (add-hook 'libmpdel-current-playlist-changed-hook 'awesome-tray-mpd-command-update-cache)


### PR DESCRIPTION
when it is in pdf-view-mode, location info is useless, so let's combine them with `location-or-page` module.