### PR TITLE
Globalized input method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The load-path is usually `~/elisp/`. It's set in your `~/.emacs` like this:
 - `awesome-tray-github-update-duration`: Update duration of the github notification, in seconds.
 - `awesome-tray-github-erase-duration`: Github notification time before it gets removed from the bar, in seconds.
 - `awesome-tray-meow-show-mode`: If non-nil, show current meow mode in the meow module.
+- `awesome-tray-input-method-default-style`: Input method indicator you want to show when no input method is toggled on.
+- `awesome-tray-input-method-local-style`: Input method indicator for your local input method.
+- `awesome-tray-input-method-local-methods`: List of input methods as your local input method. If input method is toggled on, but not a member of this list, `input-method-title` will display in as input method indicator in awesome-tray, such as "DE@" for German. Default is "rime".
 
 ## Dangerous options
 Please read the docstring for those variables

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -71,8 +71,9 @@
 ;; `awesome-tray-refresh-idle-delay'
 ;; `awesome-tray-buffer-name-buffer-changed'
 ;; `awesome-tray-buffer-name-buffer-changed-style'
-;; `awesome-tray-input-method-en-style'
-;; `awesome-tray-input-method-zh-style'
+;; `awesome-tray-input-method-default-style'
+;; `awesome-tray-input-method-local-style'
+;; `awesome-tray-input-method-local-methods'
 ;; `awesome-tray-buffer-read-only-style'
 ;;
 ;; All of the above can customize by:

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -849,7 +849,7 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
           (if (eq current-input-method nil)
               awesome-tray-input-method-default-style
             (if (member current-input-method awesome-tray-input-method-local-methods)
-                awesome-tray-input-method-zh-style
+                awesome-tray-input-method-local-style
               current-input-method-title))))
 
 (defun awesome-tray-module-parent-dir-info ()

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -432,14 +432,20 @@ It will make command `set-mark-command' failed if not use duration."
   :type 'boolean
   :group 'awesome-tray)
 
-(defcustom awesome-tray-input-method-en-style "EN"
-  "English input method display style for input-method module."
+(defcustom awesome-tray-input-method-default-style ""
+  "Default input method display style for input-method module."
   :type 'string
   :group 'awesome-tray)
 
-(defcustom awesome-tray-input-method-zh-style "ZH"
-  "Chinese input method display style for input-method module."
+(defcustom awesome-tray-input-method-local-style "ZH"
+  "Local input method display style for input-method module."
   :type 'string
+  :group 'awesome-tray)
+
+(defcustom awesome-tray-input-method-local-methods
+  '("rime")
+  "List of local input methods you want to display `awesome-tray-input-method-local-style'"
+  :type 'list
   :group 'awesome-tray)
 
 (defcustom awesome-tray-buffer-read-only-style "R-O"
@@ -838,9 +844,12 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
       (format "%s" awesome-tray-buffer-read-only-style)))
 
 (defun awesome-tray-module-input-method-info ()
-  (if (eq current-input-method nil)
-      (format "%s" awesome-tray-input-method-en-style)
-    (format "%s" awesome-tray-input-method-zh-style)))
+  (format "%s"
+          (if (eq current-input-method nil)
+              awesome-tray-input-method-default-style
+            (if (member current-input-method awesome-tray-input-method-local-methods)
+                awesome-tray-input-method-zh-style
+              current-input-method-title))))
 
 (defun awesome-tray-module-parent-dir-info ()
   (format "%s" (file-name-nondirectory (directory-file-name default-directory))))


### PR DESCRIPTION
If `current-input-method` is not Rime, awesome-tray still shows "ZH".
Changes in this PR:
- default no input-method indicator if no input method is toggled
- show "ZH" if current-input-method is in list `awesome-tray-input-method-local-methods`
- show `input-method-title` otherwise, such as "DE@" for German, "FR@" for French.