### PR TITLE
Make buffer state indicator configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The load-path is usually `~/elisp/`. It's set in your `~/.emacs` like this:
 - `awesome-tray-hide-mode-line`: Enabled by default, makes the mode-line very thin and highlight it when its active/inactive.
 - `awesome-tray-mode-line-active-color`: Use for customize active color.
 - `awesome-tray-mode-line-inactive-color`: Use for customize inactive color.
+- `awesome-tray-adjust-mode-line-color-enable`: Enabled by default. If non-nil, adjsut mode-line  color when buffer state changes. 
+- `awesome-tray-mode-line-modified-readonly-color`: Use for customize modified and readonly color.
+- `awesome-tray-mode-line-readonly-color`: Use for customize readonly color.
+- `awesome-tray-mode-line-modified-color`: Use for customize modified color.
 - `awesome-tray-mode-line-height`: Mode line height, default is 0.1
 - `awesome-tray-date-format`: Use to customize the date string format.
 - `awesome-tray-mpd-format`: Use to customize the mpd string format, see the variable docstring for details.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The load-path is usually `~/elisp/`. It's set in your `~/.emacs` like this:
 - `awesome-tray-hide-mode-line`: Enabled by default, makes the mode-line very thin and highlight it when its active/inactive.
 - `awesome-tray-mode-line-active-color`: Use for customize active color.
 - `awesome-tray-mode-line-inactive-color`: Use for customize inactive color.
-- `awesome-tray-adjust-mode-line-color-enable`: Enabled by default. If non-nil, adjsut mode-line  color when buffer state changes. 
+- `awesome-tray-adjust-mode-line-color-enable`: Enabled by default. If non-nil, adjust mode-line  color when buffer state changes. 
 - `awesome-tray-mode-line-modified-readonly-color`: Use for customize modified and readonly color.
 - `awesome-tray-mode-line-readonly-color`: Use for customize readonly color.
 - `awesome-tray-mode-line-modified-color`: Use for customize modified color.

--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -82,8 +82,11 @@
 
 ;;; Change log:
 ;;
+;; 2023/07/06
+;;      * Make mode-line color indicate buffer state configurable by `awesome-tray-adjust-mode-line-color-enable'.
+;;
 ;; 2023/07/01
-;;      * Make mode-line color indicator buffer state.
+;;      * Make mode-line color indicate buffer state.
 ;;
 ;; 2023/06/30
 ;;      * `awesome-tray-module-location-or-page-info' support EAF PDF Viewer
@@ -314,6 +317,11 @@ If nil, don't update the awesome-tray automatically."
   "Modified color."
   :type 'string
   :group 'awesome-tray)
+
+(defcustom awesome-tray-adjust-mode-line-color-enable t
+  "If non-nil, adjust mode-line color when buffer state changes."
+  :group 'awesome-tray
+  :type 'boolean)
 
 (defcustom awesome-tray-mode-line-height 0.1
   "Height of mode line."
@@ -1292,7 +1300,8 @@ If right is non nil, replace to the right"
   (interactive)
 
   ;; Adjust mode-line color with buffer's state.
-  (awesome-tray-adjust-mode-line-color)
+  (when awesome-tray-adjust-mode-line-color-enable
+    (awesome-tray-adjust-mode-line-color))
 
   (let* ((tray-active-info (awesome-tray-build-active-info))
          ;; Get minibuffer content.


### PR DESCRIPTION
`awesome-tray-adjust-mode-line-color-enable`: 
Enabled by default. If non-nil, adjust mode-line  color when buffer state changes. 