### PR TITLE
Fix right aligned line wrap.

### DIFF
--- a/awesome-tray.el
+++ b/awesome-tray.el
@@ -1277,7 +1277,23 @@ If right is non nil, replace to the right"
                   ('left (propertize "  " 'cursor 1 'display
                                      `(space :align-to (- left-fringe ,wid))))
                   ('right (propertize "  " 'cursor 1 'display
-                                      `(space :align-to (- right-fringe ,wid)))))))
+                                      `(space :align-to (- right-fringe
+                                                           ,(if (display-graphic-p)
+                                                                (if (= (nth 1 (window-fringes)) 0)
+                                                                    ;; no right fringe, need 1 char padding to avoid
+                                                                    ;; line wrap
+                                                                    1
+                                                                  (if (and (not overflow-newline-into-fringe)
+                                                                           (= awesome-tray-info-padding-right 0))
+                                                                      ;; need 1 pixel padding to avoid line wrap when
+                                                                      ;; overflow-newline-into-fringe is nil
+                                                                      '(1)
+                                                                    '(0)))
+                                                              (if (= awesome-tray-info-padding-right 0)
+                                                                  ;; need 1 char in TUI to avoid line wrap
+                                                                  1
+                                                                0))
+                                                           ,wid)))))))
 
       (setq awesome-tray-text (concat (if awesome-tray-second-line "\n") spc text))
 


### PR DESCRIPTION
Add offset to avoid line wrap when aligned to the right:
1. Add 1 pixel if right fringe present and overflow-newline-into-fringe nil.
2. Add 1 char if no right fringe.
2. Add 1 char if in TUI.

If awesome-tray-info-padding-right is set to something else than 0 keep the old behavior.

I had a similar problem at https://github.com/emacs-sideline/sideline/issues/18